### PR TITLE
Pass `callback` to `_startAnimation` when calling recursively.

### DIFF
--- a/index.js
+++ b/index.js
@@ -384,7 +384,7 @@ var createAnimatableComponent = function(component) {
       }).start(endState => {
         iteration++;
         if(endState.finished && this.props.animation && (iterationCount === 'infinite' || iteration < iterationCount)) {
-          this._startAnimation(duration, iteration);
+          this._startAnimation(duration, iteration, callback);
         } else if(callback) {
           callback(endState);
         }


### PR DESCRIPTION
This is necessary in order for `onAnimationEnd` to be called when `iterationCount` >1