### PR TITLE
Convert require to import from react as opposed to react-native

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,17 @@
 'use strict';
 
-var React = require('react-native');
+var React, { PropTypes } = require('react');
+var ReactNative = require('react-native');
+
 var {
   StyleSheet,
-  PropTypes,
   Animated,
   Easing,
   Dimensions,
   View,
   Text,
   Image,
-} = React;
+} = ReactNative;
 
 // Transform an object to an array the way react native wants it for transform styles
 // { a: x, b: y } => [{ a: x }, { b: y }]

--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
 'use strict';
 
-var React, { PropTypes } = require('react');
+var React = require('react');
 var ReactNative = require('react-native');
+
+var { PropTypes } = React;
 
 var {
   StyleSheet,


### PR DESCRIPTION
Hi!

React-native v0.25 was released, bringing with it a new way to import stuff. `React`, along with `PropTypes` and `Component`, should now be imported from the react package. This pull request fixes react-native-animatable to be compatible with RN25.