### PR TITLE
Fix Android example by adding application android:name in AndroidMainfest

### DIFF
--- a/Example/android/app/src/main/AndroidManifest.xml
+++ b/Example/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,8 @@
       android:allowBackup="true"
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
-      android:theme="@style/AppTheme">
+      android:theme="@style/AppTheme"
+      android:name=".MainApplication">
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name">


### PR DESCRIPTION
When running the Android example, the app would crash and I saw the error described here in the logs: https://github.com/facebook/react-native/issues/8215

I've added `android:name` for `application` in the manifest file and that seemed to have solved the problem.