### PR TITLE
Add `tintColor` to inpterpolation style properties

### DIFF
--- a/createAnimatableComponent.js
+++ b/createAnimatableComponent.js
@@ -28,6 +28,8 @@ const INTERPOLATION_STYLE_PROPERTIES = [
   // Text styles
   'color',
   'textDecorationColor',
+  // Image styles
+  'tintColor',
 ];
 
 // Create a copy of `source` without `keys`


### PR DESCRIPTION
I've tested this locally and this appears to work.

A great use-case for this is TabBar or NavBar with icons that need to animate to different colors.

Let me know if there are any issues.