### PR TITLE
Add transition callbacks

### DIFF
--- a/createAnimatableComponent.js
+++ b/createAnimatableComponent.js
@@ -105,7 +105,6 @@ function transitionToValue(
   onTransitionBegin,
   onTransitionEnd,
 ) {
-  onTransitionBegin(property);
   const animation = (duration || easing || delay) ?
     Animated.timing(transitionValue, {
       toValue,
@@ -117,6 +116,7 @@ function transitionToValue(
       useNativeDriver,
     }) :
     Animated.spring(transitionValue, { toValue, useNativeDriver });
+  setTimeout(() => onTransitionBegin(property), delay);
   animation.start(() => onTransitionEnd(property));
 }
 

--- a/createAnimatableComponent.js
+++ b/createAnimatableComponent.js
@@ -503,8 +503,8 @@ export default function createAnimatableComponent(WrappedComponent) {
             easing,
             this.props.useNativeDriver,
             delay,
-            this.props.onTransitionBegin,
-            this.props.onTransitionEnd,
+            prop => this.props.onTransitionBegin(prop),
+            prop => this.props.onTransitionEnd(prop),
           );
         } else {
           let currentTransitionValue = currentTransitionValues[property];
@@ -537,8 +537,8 @@ export default function createAnimatableComponent(WrappedComponent) {
           easing,
           this.props.useNativeDriver,
           delay,
-          this.props.onTransitionBegin,
-          this.props.onTransitionEnd,
+          prop => this.props.onTransitionBegin(prop),
+          prop => this.props.onTransitionEnd(prop),
         );
       });
     }

--- a/createAnimatableComponent.js
+++ b/createAnimatableComponent.js
@@ -95,14 +95,18 @@ function makeInterpolatedStyle(compiledAnimation, animationValue) {
 }
 
 function transitionToValue(
+  property,
   transitionValue,
   toValue,
   duration,
   easing,
   useNativeDriver = false,
   delay,
+  onTransitionBegin,
+  onTransitionEnd,
 ) {
-  if (duration || easing || delay) {
+  onTransitionBegin(property);
+  const animation = (duration || easing || delay) ?
     Animated.timing(transitionValue, {
       toValue,
       delay,
@@ -111,10 +115,9 @@ function transitionToValue(
         ? easing
         : EASING_FUNCTIONS[easing || 'ease'],
       useNativeDriver,
-    }).start();
-  } else {
-    Animated.spring(transitionValue, { toValue, useNativeDriver }).start();
-  }
+    }) :
+    Animated.spring(transitionValue, { toValue, useNativeDriver });
+  animation.start(() => onTransitionEnd(property));
 }
 
 // Make (almost) any component animatable, similar to Animated.createAnimatedComponent
@@ -152,6 +155,8 @@ export default function createAnimatableComponent(WrappedComponent) {
       },
       onAnimationBegin: PropTypes.func,
       onAnimationEnd: PropTypes.func,
+      onTransitionBegin: PropTypes.func,
+      onTransitionEnd: PropTypes.func,
       style: PropTypes.oneOfType([
         PropTypes.number,
         PropTypes.array,
@@ -173,6 +178,8 @@ export default function createAnimatableComponent(WrappedComponent) {
       iterationCount: 1,
       onAnimationBegin() {},
       onAnimationEnd() {},
+      onTransitionBegin() {},
+      onTransitionEnd() {},
       style: undefined,
       transition: undefined,
       useNativeDriver: false,
@@ -489,12 +496,15 @@ export default function createAnimatableComponent(WrappedComponent) {
           transitionStyle === transitionValue
         ) {
           transitionToValue(
+            property,
             transitionValue,
             toValue,
             duration,
             easing,
             this.props.useNativeDriver,
             delay,
+            this.props.onTransitionBegin,
+            this.props.onTransitionEnd,
           );
         } else {
           let currentTransitionValue = currentTransitionValues[property];
@@ -520,12 +530,15 @@ export default function createAnimatableComponent(WrappedComponent) {
         const transitionValue = this.state.transitionValues[property];
         const toValue = toValues[property];
         transitionToValue(
+          property,
           transitionValue,
           toValue,
           duration,
           easing,
           this.props.useNativeDriver,
           delay,
+          this.props.onTransitionBegin,
+          this.props.onTransitionEnd,
         );
       });
     }

--- a/typings/react-native-animatable.d.ts
+++ b/typings/react-native-animatable.d.ts
@@ -1,4 +1,4 @@
-import { 
+import {
     NativeMethodsMixin,
     ViewProperties,
     TextProperties,
@@ -121,6 +121,8 @@ interface AnimatableProperties<S extends {}> {
     useNativeDriver?: boolean;
     onAnimationBegin?: Function;
     onAnimationEnd?: Function;
+    onTransitionBegin?: (property: string) => void;
+    onTransitionEnd?: (property: string) => void;
 }
 
 type AnimatableAnimationMethods =
@@ -179,4 +181,3 @@ export const Text : AnimatableComponent<TextProperties, TextStyle>;
 export type Text = AnimatableComponent<TextProperties, TextStyle>;
 export const Image : AnimatableComponent<ImageProperties, ImageStyle>;
 export type Image = AnimatableComponent<ImageProperties, ImageStyle>;
-


### PR DESCRIPTION
Adds the `onTransitionBegin` and `onTransitionEnd` callbacks that are invoked when transitions occur. The property that is transitioning is provided to the callback so that users can determine which property triggered the transition in situations where there are multiple transitioning
properties.

Fixes #85