### PR TITLE
Fix transition typings

### DIFF
--- a/typings/react-native-animatable.d.ts
+++ b/typings/react-native-animatable.d.ts
@@ -117,7 +117,7 @@ interface AnimatableProperties<S extends {}> {
     direction?: 'normal' | 'reverse' | 'alternate'| 'alternate-reverse';
     easing?: Easing;
     iterationCount?: number | 'infinite';
-    transition?: keyof S | keyof S[];
+    transition?: keyof S | Array<keyof S>;
     useNativeDriver?: boolean;
     onAnimationBegin?: Function;
     onAnimationEnd?: Function;


### PR DESCRIPTION
Allows assigning multiple transition prooperties now. `keyof S[]`
is the keys of an array of the generic property which is `length`,
etc.