### PR TITLE
Update transition typing to ReadonlyArray

### DIFF
--- a/typings/react-native-animatable.d.ts
+++ b/typings/react-native-animatable.d.ts
@@ -118,7 +118,7 @@ interface AnimatableProperties<S extends {}> {
     easing?: Easing;
     iterationCount?: number | 'infinite';
     iterationDelay?: number;
-    transition?: keyof S | Array<keyof S>;
+    transition?: keyof S | ReadonlyArray<keyof S>;
     useNativeDriver?: boolean;
     onAnimationBegin?: Function;
     onAnimationEnd?: Function;


### PR DESCRIPTION
We never make any modifications to the array so there is no need for it to be an `Array`