### PR TITLE
fix(propTypes): fix prop-type removal

### DIFF
--- a/createAnimatableComponent.js
+++ b/createAnimatableComponent.js
@@ -563,7 +563,7 @@ export default function createAnimatableComponent(WrappedComponent) {
         throw new Error('You cannot combine animation and transition props');
       }
       const restProps = omit(
-        Object.keys(AnimatableComponent.propTypes),
+        ['animation', 'duration', 'direction', 'delay', 'easing', 'iterationCount', 'iterationDelay', 'onAnimationBegin', 'onAnimationEnd', 'onTransitionBegin', 'onTransitionEnd', 'style', 'transition', 'useNativeDriver'],
         this.props,
       );
 


### PR DESCRIPTION
react-native-animatable wasn't working in production on projects using transform-react-remove-prop-types because the prop-types were getting removed and the Object.keys was being called with undefined.