### PR TITLE
feat(percentageAnims): Allow percentage animations for non-interpolated values

### DIFF
--- a/createAnimatableComponent.js
+++ b/createAnimatableComponent.js
@@ -239,7 +239,7 @@ export default function createAnimatableComponent(WrappedComponent) {
       );
       Object.keys(currentTransitionValues).forEach(key => {
         const value = currentTransitionValues[key];
-        if (INTERPOLATION_STYLE_PROPERTIES.indexOf(key) !== -1) {
+        if (INTERPOLATION_STYLE_PROPERTIES.indexOf(key) !== -1 || typeof(value) !== 'number') {
           transitionValues[key] = new Animated.Value(0);
           styleValues[key] = value;
         } else {
@@ -449,7 +449,7 @@ export default function createAnimatableComponent(WrappedComponent) {
           transitionValue = new Animated.Value(0);
         }
         const needsInterpolation =
-          INTERPOLATION_STYLE_PROPERTIES.indexOf(property) !== -1;
+          INTERPOLATION_STYLE_PROPERTIES.indexOf(property) !== -1 || typeof(value) !== 'number';
         const needsZeroClamping =
           ZERO_CLAMPED_STYLE_PROPERTIES.indexOf(property) !== -1;
         if (needsInterpolation) {
@@ -498,7 +498,7 @@ export default function createAnimatableComponent(WrappedComponent) {
       Object.keys(toValuesFlat).forEach(property => {
         const toValue = toValuesFlat[property];
         const needsInterpolation =
-          INTERPOLATION_STYLE_PROPERTIES.indexOf(property) !== -1;
+          INTERPOLATION_STYLE_PROPERTIES.indexOf(property) !== -1 || typeof(value) !== 'number';
         const needsZeroClamping =
           ZERO_CLAMPED_STYLE_PROPERTIES.indexOf(property) !== -1;
         const transitionStyle = this.state.transitionStyle[property];


### PR DESCRIPTION
Because some values are not regarded as interpolated values (such as width, margins, etc.), using a generic transition with percentage values causes an error. This pr allows those values to be interpolated if their value is a non-number (i.e. a string percentage).