### PR TITLE
added react and react-native as peer dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
+.idea

--- a/package.json
+++ b/package.json
@@ -65,5 +65,9 @@
   },
   "dependencies": {
     "prop-types": "^15.5.10"
+  },
+  "peerDependencies": {
+    "react": "*",
+    "react-native": "*"
   }
 }


### PR DESCRIPTION
React and React-Native dependencies are not mentionned in package.json except in the development environment, yet the index.js file requires React and React-Native. As such these should be mentionned as peer dependencies, for example in case an other library relies on it (e.g react-native-modal 😄 )