### PR TITLE
Fix transitions aborting on repeated style values

### DIFF
--- a/createAnimatableComponent.js
+++ b/createAnimatableComponent.js
@@ -330,7 +330,18 @@ export default function createAnimatableComponent(WrappedComponent) {
       } = props;
 
       if (transition) {
+        const oldProps = this.props;
         const values = getStyleValues(transition, props.style);
+        // Don't transition values that are already correct or currently transitioning to the new value.
+        // Prevents transitions being aborted when props are repeated before transition ends.
+        const oldValues = getStyleValues(oldProps.transition, oldProps.style);
+        for (styleAttribute in values) {
+          const oldValue = oldValues[styleAttribute];
+          const newValue = values[styleAttribute];
+          if (oldValue === newValue) {
+            delete values[styleAttribute];
+          }
+        }
         this.transitionTo(values, duration, easing, delay);
       } else if (!deepEquals(animation, this.props.animation)) {
         if (animation) {


### PR DESCRIPTION
Before this fix the following could happen:

1. Button receives props 
{
  otherProp: valA
  style: {translateY: 50}
}
2. Transition starts to translate button to 50.
3. While transition is happening Button receives the following props
{
  otherProp: valB
  style: {translateY: 50}
}
4. Transition is aborted and Button "jerks" to the target state of the transition.

This update makes react-native-animatable ignore repeated style props and only start transitions when new values are received.