### PR TITLE
Make it possible to override isInteraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ You can create your own simple transitions of a style property of your own choos
 |**`onTransitionBegin`**|A function that is called when the transition of a style has been started. The function is called with a `property` argument to differentiate between styles. |*None*|
 |**`onTransitionEnd`**|A function that is called when the transition of a style has been completed successfully or cancelled. The function is called with a `property` argument to differentiate between styles. |*None*|
 |**`useNativeDriver`**|Whether to use native or JavaScript animation driver. Native driver can help with performance but cannot handle all types of styling.  |`false`|
+|**`isInteraction`**|Whether or not this animation creates an "interaction handle" on the InteractionManager.  |`false` if `iterationCount` is less than or equal to one|
 
 ### Imperative Usage
 

--- a/createAnimatableComponent.js
+++ b/createAnimatableComponent.js
@@ -591,6 +591,7 @@ export default function createAnimatableComponent(WrappedComponent) {
           'style',
           'transition',
           'useNativeDriver',
+          'isInteraction',
         ],
         this.props,
       );

--- a/createAnimatableComponent.js
+++ b/createAnimatableComponent.js
@@ -170,6 +170,7 @@ export default function createAnimatableComponent(WrappedComponent) {
         PropTypes.arrayOf(PropTypes.string),
       ]),
       useNativeDriver: PropTypes.bool,
+      isInteraction: PropTypes.bool,
     };
 
     static defaultProps = {
@@ -187,6 +188,7 @@ export default function createAnimatableComponent(WrappedComponent) {
       style: undefined,
       transition: undefined,
       useNativeDriver: false,
+      isInteraction: undefined,
     };
 
     constructor(props) {

--- a/createAnimatableComponent.js
+++ b/createAnimatableComponent.js
@@ -396,7 +396,7 @@ export default function createAnimatableComponent(WrappedComponent) {
 
     startAnimation(duration, iteration, iterationDelay, callback) {
       const { animationValue, compiledAnimation } = this.state;
-      const { direction, iterationCount, useNativeDriver } = this.props;
+      const { direction, iterationCount, useNativeDriver, isInteraction } = this.props;
       let easing = this.props.easing || compiledAnimation.easing || 'ease';
       let currentIteration = iteration || 0;
       const fromValue = getAnimationOrigin(currentIteration, direction);
@@ -417,7 +417,7 @@ export default function createAnimatableComponent(WrappedComponent) {
       const config = {
         toValue,
         easing,
-        isInteraction: iterationCount <= 1,
+        isInteraction: typeof isInteraction !== "undefined" ? isInteraction : iterationCount <= 1,
         duration: duration || this.props.duration || 1000,
         useNativeDriver,
         delay: iterationDelay || 0,

--- a/typings/react-native-animatable.d.ts
+++ b/typings/react-native-animatable.d.ts
@@ -126,6 +126,7 @@ interface AnimatableProperties<S extends {}> {
     iterationDelay?: number;
     transition?: keyof S | ReadonlyArray<keyof S>;
     useNativeDriver?: boolean;
+    isInteraction?: boolean;
     onAnimationBegin?: Function;
     onAnimationEnd?: Function;
     onTransitionBegin?: (property: string) => void;


### PR DESCRIPTION
This pull request makes it possible to override isInteraction for the animation. As it is today non-looping (iterationCount <= 1) animatinos will always set isInteraction to true and looping animations will set it to false.

With this pull request that behaviour can be overriden by defining isInteraction as a prop on the component.

I needed this for a long running animation that shouldn't block interaction mananger. I also saw that someone else asked for the same feature a while ago (https://github.com/oblador/react-native-animatable/issues/241).