### PR TITLE
Disable iterationDelay delay on the beginning of animation

### DIFF
--- a/createAnimatableComponent.js
+++ b/createAnimatableComponent.js
@@ -422,7 +422,7 @@ export default function createAnimatableComponent(WrappedComponent) {
         isInteraction: typeof isInteraction !== "undefined" ? isInteraction : iterationCount <= 1,
         duration: duration || this.props.duration || 1000,
         useNativeDriver,
-        delay: iterationDelay || 0,
+        delay: (iterationDelay && currentIteration > 0) ? iterationDelay : 0,
       };
 
       Animated.timing(animationValue, config).start(endState => {


### PR DESCRIPTION
In the current version, when an "iterationDelay" is applied to pause the animation between iterations, the same iterationDelay is applied on the beginning of the first animation too. To apply pause/delay before the beginning of first animation, there already exists the "delay" prop.

Changes in this pull request will make sure the"iterationDelay" is only applied to the second and subsequent animations.

PS: The minor one line fix worked for me. Please take a look and let me know if I've missed any edge cases or done something wrong, I am happy to fix and resubmit the pull request in case any issues are found.